### PR TITLE
added parsing of env variables for announcements

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -80,6 +80,9 @@ function parse (config) {
   config.app.response.dmprefix = process.env.APP_RESPONSE_DMPREFIX || config.app.response.dmprefix;
   config.app.response.channelprefix = process.env.APP_RESPONSE_CHANNELPREFIX || config.app.response.channelprefix;
 
+  config.app.announce.channels = parseList(process.env.APP_ANNOUNCE_CHANNELS) || config.app.announce.channels;
+  config.app.announce.times = parseList(process.env.APP_ANNOUNCE_TIMES) || config.app.announce.times;
+
   config.slack.token = process.env.SLACK_TOKEN || config.slack.token;
   config.slack.autoReconnect = parseBool(process.env.SLACK_AUTO_RECONNECT) || config.slack.autoReconnect;
   config.slack.autoMark = parseBool(process.env.SLACK_AUTO_MARK) || config.slack.autoMark;


### PR DESCRIPTION
Hi,

I wanted to use the announcements feature but saw that the code for parsing those env variables was missing. This commit adds them.

Cheers,

Johannes